### PR TITLE
Seen

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -77,6 +77,7 @@ type Conversation implements Node {
 type Message implements Node {
   id:ID!
   createdAt: Date!
+  seen: Boolean!
   body: String
   author: User @relationship(path:"<-AUTHORED-")
   chat: Conversation @relationship(path:"<-HELD-")

--- a/src/modules/message/mutations.js
+++ b/src/modules/message/mutations.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { stripId } from 'helpers/data';
+import { isNil } from 'lodash';
 
 export const Send = types => ({
   name: 'SendMessage',
@@ -24,14 +25,52 @@ export const Send = types => ({
       { id: stripId(conversationId) },
       { updatedAt: new Date() },
     );
+    assert(currentConversation, "Conversation doesn't exist!");
+
     // fails if the db call fails
     await db.insert('messages', {
       createdAt: new Date(),
       authoredByUserId: currentUserId,
       heldByConversationId: stripId(conversationId),
+      seen: false,
       body,
     });
 
     return { currentConversation };
+  },
+});
+
+export const View = types => ({
+  name: 'ViewMessage',
+  inputFields: {
+    messageId: types.ID,
+  },
+  outputFields: {
+    changedConversation: types.Conversation,
+  },
+  mutateAndGetPayload: async (
+    { messageId },
+    { db }
+  ) => {
+    // update the message
+    const updatedMessage = await db.update(
+      'messages',
+      { id: stripId(messageId) },
+      { seen: true },
+    );
+    assert(!isNil(updatedMessage), "Message doesn't exist!");
+
+    // update the currentConversation
+    const conversation = await db.update(
+      'conversations',
+      { id: updatedMessage[0].heldByConversationId },
+      { updatedAt: new Date() },
+    );
+    assert(!isNil(conversation), "Conversation doesn't exist!");
+    console.log(conversation);
+
+    const changedConversation = conversation[0];
+
+    return { changedConversation };
   },
 });

--- a/src/modules/message/mutations.js
+++ b/src/modules/message/mutations.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { stripId } from 'helpers/data';
-import { isNil } from 'lodash';
+
 
 export const Send = types => ({
   name: 'SendMessage',
@@ -53,7 +53,7 @@ export const View = types => ({
     { db }
   ) => {
     // update the message
-    const [ updatedMessage ] = await db.update(
+    const [updatedMessage] = await db.update(
       'messages',
       { id: stripId(messageId) },
       { seen: true },
@@ -61,7 +61,7 @@ export const View = types => ({
     assert(updatedMessage, "Message doesn't exist!");
 
     // update the currentConversation
-    const [ changedConversation ] = await db.update(
+    const [changedConversation] = await db.update(
       'conversations',
       { id: updatedMessage.heldByConversationId },
       { updatedAt: new Date() },

--- a/src/modules/message/mutations.js
+++ b/src/modules/message/mutations.js
@@ -53,23 +53,20 @@ export const View = types => ({
     { db }
   ) => {
     // update the message
-    const updatedMessage = await db.update(
+    const [ updatedMessage ] = await db.update(
       'messages',
       { id: stripId(messageId) },
       { seen: true },
     );
-    assert(!isNil(updatedMessage), "Message doesn't exist!");
+    assert(updatedMessage, "Message doesn't exist!");
 
     // update the currentConversation
-    const conversation = await db.update(
+    const [ changedConversation ] = await db.update(
       'conversations',
-      { id: updatedMessage[0].heldByConversationId },
+      { id: updatedMessage.heldByConversationId },
       { updatedAt: new Date() },
     );
-    assert(!isNil(conversation), "Conversation doesn't exist!");
-    console.log(conversation);
-
-    const changedConversation = conversation[0];
+    assert(changedConversation, "Conversation doesn't exist!");
 
     return { changedConversation };
   },

--- a/src/modules/post/mutations.js
+++ b/src/modules/post/mutations.js
@@ -67,6 +67,7 @@ export const Update = types => ({
         updatedAt: new Date(),
       },
     );
+    assert(changedPost, "Couldn't find that Post");
 
     return { changedPost };
   },

--- a/src/modules/user/mutations.js
+++ b/src/modules/user/mutations.js
@@ -178,7 +178,7 @@ export const Update = types => ({
       { id: currentUserId },
       updates,
     );
-    assert(!isNil(changedUser), "Didn't find that user.");
+    assert(changedUser, "Didn't find that user.");
 
     return { changedUser };
   },

--- a/src/modules/user/mutations.js
+++ b/src/modules/user/mutations.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import bcrypt from 'bcrypt-as-promised';
 import uuid from 'uuid-js';
-import { chain, isUndefined, isNull } from 'lodash';
+import { chain, isUndefined, isNil } from 'lodash';
 import { stripId } from 'helpers/data';
 
 export const SignIn = types => ({
@@ -165,7 +165,7 @@ export const Update = types => ({
       .omit('locationId')
       .merge({ hostedByLocationId })
       .omitBy(isUndefined)
-      .omitBy(isNull)
+      .omitBy(isNil)
       .value();
 
     const updates = {
@@ -173,12 +173,12 @@ export const Update = types => ({
       updatedAt: new Date(),
     };
 
-    // the update method returns an array of updated rows
     const returnUser = await db.update(
       'users',
       { id: currentUserId },
       updates,
     );
+    assert(!isNil(returnUser), "Didn't find that user.");
 
     const changedUser = returnUser[0];
 

--- a/src/modules/user/mutations.js
+++ b/src/modules/user/mutations.js
@@ -173,14 +173,12 @@ export const Update = types => ({
       updatedAt: new Date(),
     };
 
-    const returnUser = await db.update(
+    const [changedUser] = await db.update(
       'users',
       { id: currentUserId },
       updates,
     );
-    assert(!isNil(returnUser), "Didn't find that user.");
-
-    const changedUser = returnUser[0];
+    assert(!isNil(changedUser), "Didn't find that user.");
 
     return { changedUser };
   },


### PR DESCRIPTION
This:
- adds Boolean seen field to message 
- ViewMessage mutation 
- refactors some update calls that weren't using object deconstruction 
- adds asserts onto update calls (insert calls will error if they fail, but update calls will return an empty list if they don't update anything)